### PR TITLE
Fix package version in installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add the package into your composer.json:
     {
         "require-dev": {
             "codeception/codeception": "*",
-            "captbaritone/mailcatcher-codeception-module": "*"
+            "captbaritone/mailcatcher-codeception-module": "dev-master"
         }
     }
 


### PR DESCRIPTION
When version was set to "*":

```
Problem 1
- The requested package captbaritone/mailcatcher-codeception-module could not be found in any version, there may be a typo in the package name.
```
