### PR TITLE
Trim potential slashes on config url

### DIFF
--- a/src/MailCatcher.php
+++ b/src/MailCatcher.php
@@ -24,7 +24,7 @@ class MailCatcher extends Module
 
     public function _initialize()
     {
-        $url = $this->config['url'] . ':' . $this->config['port'];
+        $url = trim($this->config['url'], '/') . ':' . $this->config['port'];
         $this->mailcatcher = new \Guzzle\Http\Client($url);
     }
 
@@ -358,4 +358,3 @@ class MailCatcher extends Module
     }
 
 }
-


### PR DESCRIPTION
Avoid this kind of config...

``` yaml
MailCatcher:
    url: 'http://localhost/'
    port: '1080'
```

... to generate this URL
=> http://localhost/:1080

New url with trim.
=> http://localhost:1080
