### PR TITLE
fixed seeEmailCount assertion message

### DIFF
--- a/src/MailCatcher.php
+++ b/src/MailCatcher.php
@@ -222,7 +222,7 @@ class MailCatcher extends Module
     {
         $messages = $this->messages();
         $count = count($messages);
-        $this->assertEquals($count,$expected);
+        $this->assertEquals($expected, $count);
     }
 
     // ----------- HELPER METHODS BELOW HERE -----------------------//


### PR DESCRIPTION
seeEmailCount had $expected and $count in the wrong order, treating $expected as actual result.