### PR TITLE
Allow setting Guzzle default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,14 @@ port of your site's MailCatcher installation:
                 url: 'http://project.dev'
                 port: '1080'
 
+You will then need to rebuild your actor class:
+
+    php codecept.phar build
+
+## Optional Configuration
+
 If you need to specify some special options (e.g. SSL verification or authentication
-headers), you can specify all of the allowed [Guzzle options](https://guzzle.readthedocs.org/en/5.3/clients.html#request-options):
+headers), you can set all of the allowed [Guzzle request options](https://guzzle.readthedocs.org/en/5.3/clients.html#request-options):
 
     class_name: WebGuy
     modules:
@@ -49,7 +55,7 @@ headers), you can specify all of the allowed [Guzzle options](https://guzzle.rea
             MailCatcher:
                 url: 'http://project.dev'
                 port: '1080'
-                defaultOptions:
+                guzzleRequestOptions:
                     verify: false
                     debug: true
                     version: 1.0

--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ port of your site's MailCatcher installation:
                 url: 'http://project.dev'
                 port: '1080'
 
+If you need to specify some special options (e.g. SSL verification or authentication
+headers), you can specify all of the allowed [Guzzle options](https://guzzle.readthedocs.org/en/5.3/clients.html#request-options):
+
+    class_name: WebGuy
+    modules:
+        enabled:
+            - MailCatcher
+        config:
+            MailCatcher:
+                url: 'http://project.dev'
+                port: '1080'
+                defaultOptions:
+                    verify: false
+                    debug: true
+                    version: 1.0
+
 You will then need to rebuild your actor class:
 
     php codecept.phar build

--- a/src/MailCatcher.php
+++ b/src/MailCatcher.php
@@ -11,11 +11,10 @@ class MailCatcher extends Module
      */
     protected $mailcatcher;
 
-
     /**
      * @var array
      */
-    protected $config = array('url', 'port');
+    protected $config = array('url', 'port', 'defaultOptions');
 
     /**
      * @var array
@@ -26,6 +25,12 @@ class MailCatcher extends Module
     {
         $url = trim($this->config['url'], '/') . ':' . $this->config['port'];
         $this->mailcatcher = new \Guzzle\Http\Client($url);
+
+        if (isset($this->config['defaultOptions'])) {
+            foreach ($this->config['defaultOptions'] as $option => $value) {
+                $this->mailcatcher->setDefaultOption($option, $value);
+            }
+        }
     }
 
 

--- a/src/MailCatcher.php
+++ b/src/MailCatcher.php
@@ -14,7 +14,7 @@ class MailCatcher extends Module
     /**
      * @var array
      */
-    protected $config = array('url', 'port', 'defaultOptions');
+    protected $config = array('url', 'port', 'guzzleRequestOptions');
 
     /**
      * @var array
@@ -26,8 +26,8 @@ class MailCatcher extends Module
         $url = trim($this->config['url'], '/') . ':' . $this->config['port'];
         $this->mailcatcher = new \Guzzle\Http\Client($url);
 
-        if (isset($this->config['defaultOptions'])) {
-            foreach ($this->config['defaultOptions'] as $option => $value) {
+        if (isset($this->config['guzzleRequestOptions'])) {
+            foreach ($this->config['guzzleRequestOptions'] as $option => $value) {
                 $this->mailcatcher->setDefaultOption($option, $value);
             }
         }


### PR DESCRIPTION
This optional feature allows to set of all Guzzle options to ensure some connection specials. E.g. disabling the SSL verification or enabling connection debug, etc. ```defaultOptions``` are not required, so the introduction of the new configuration value is fully backward compatible.