### PR TITLE
Add helper for finding last email sent FROM an address

### DIFF
--- a/src/MailCatcher.php
+++ b/src/MailCatcher.php
@@ -113,10 +113,25 @@ class MailCatcher extends Module
      **/
     public function seeInLastEmailTo($address, $expected)
     {
-        $email = $this->lastMessageFrom($address);
+        $email = $this->lastMessageTo($address);
         $this->seeInEmail($email, $expected);
 
     }
+
+    /**
+     * See In Last Email From
+     *
+     * Look for a string in the most recent email sent from $address
+     *
+     * @return voide
+     * @author Carlos Gottberg <42linoge@gmail.com>
+     **/
+    public function seeInLastEmailFrom($address, $expected)
+    {
+        $email = $this->lastMessageFrom($address);
+        $this->seeInEmail($email, $expected);
+    }
+
     /**
      * Don't See In Last Email To
      *
@@ -126,7 +141,7 @@ class MailCatcher extends Module
      **/
     public function dontSeeInLastEmailTo($address, $unexpected)
     {
-        $email = $this->lastMessageFrom($address);
+        $email = $this->lastMessageTo($address);
         $this->dontSeeInEmail($email, $unexpected);
     }
 
@@ -140,7 +155,7 @@ class MailCatcher extends Module
      **/
     public function seeInLastEmailSubjectTo($address, $expected)
     {
-        $email = $this->lastMessageFrom($address);
+        $email = $this->lastMessageTo($address);
         $this->seeInEmailSubject($email, $expected);
 
     }
@@ -154,7 +169,7 @@ class MailCatcher extends Module
      **/
     public function dontSeeInLastEmailSubjectTo($address, $unexpected)
     {
-        $email = $this->lastMessageFrom($address);
+        $email = $this->lastMessageTo($address);
         $this->dontSeeInEmailSubject($email, $unexpected);
     }
 
@@ -179,14 +194,14 @@ class MailCatcher extends Module
     }
 
     /**
-     * Last Message From
+     * Last Message To
      *
      * Get the most recent email sent to $address
      *
      * @return obj
      * @author Jordan Eldredge <jordaneldredge@gmail.com>
      **/
-    public function lastMessageFrom($address)
+    public function lastMessageTo($address)
     {
       $ids = [];
       $messages = $this->messages();
@@ -206,6 +221,40 @@ class MailCatcher extends Module
         return $this->emailFromId(max($ids));
 
       $this->fail("No messages sent to {$address}");
+    }
+
+    /**
+     * Last Message From
+     * Get the most recent email sent from $address
+     *
+     * @return obj
+     * @author Carlos Gottberg <42linoge@gmail.com>
+     **/
+    public function lastMessageFrom($address)
+    {
+        $ids = [];
+        $messages = $this->messages();
+
+        if (empty($messages)) {
+            $this->fail("No messages received");
+        }
+
+        $getIds = function ($ids, $message) {
+            if (strpos($message->sender, $address) !== false) {
+                $ids[] = $message['id'];
+            }
+            return $ids;
+        };
+
+        $ids = array_reduce($messages,
+                            $getIds,
+                            []);
+
+        if (count($ids) > 0) {
+            return $this->emailFromId(max($ids));
+        }
+
+        $this->fail("No messages sent to {$address}");
     }
 
     /**
@@ -248,7 +297,7 @@ class MailCatcher extends Module
      **/
     public function grabMatchesFromLastEmailTo($address, $regex)
     {
-        $email = $this->lastMessageFrom($address);
+        $email = $this->lastMessageTo($address);
         $matches = $this->grabMatchesFromEmail($email, $regex);
         return $matches;
     }

--- a/src/MailCatcher.php
+++ b/src/MailCatcher.php
@@ -240,7 +240,7 @@ class MailCatcher extends Module
         }
 
         $getIds = function ($ids, $message) {
-            if (strpos($message->sender, $address) !== false) {
+            if (strpos($message['sender'], $address) !== false) {
                 $ids[] = $message['id'];
             }
             return $ids;

--- a/src/MailCatcher.php
+++ b/src/MailCatcher.php
@@ -239,7 +239,7 @@ class MailCatcher extends Module
             $this->fail("No messages received");
         }
 
-        $getIds = function ($ids, $message) {
+        $getIds = function ($ids, $message) use ($address) {
             if (strpos($message['sender'], $address) !== false) {
                 $ids[] = $message['id'];
             }


### PR DESCRIPTION
Also, redefine the confusing lastEmailFrom function to perform
what its names indicates (retrieve last message sent FROM an address)
and leave its previous definition as lastEmailTo (retrieve last email
sent TO an address).