### PR TITLE
Allow Guzzle 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "codeception/codeception": "^2.2 || ^3.0 || ^4.0",
         "zbateson/mail-mime-parser": "^1.2"
     },


### PR DESCRIPTION
According to the [UPGRADING doc](https://github.com/guzzle/guzzle/blob/7.0/UPGRADING.md#60-to-70) and green lights on tests, there is modification between Guzzle 6 and 7 for this lib.