### PR TITLE
Fix grabMatchesFromEmail() by decoding source

### DIFF
--- a/src/Module/MailCatcher.php
+++ b/src/Module/MailCatcher.php
@@ -435,7 +435,7 @@ class MailCatcher extends Module
 
     protected function grabMatchesFromEmail(Email $email, string $regex): array
     {
-        preg_match($regex, $email->getSource(), $matches);
+        preg_match($regex, $email->getSourceQuotedPrintableDecoded(), $matches);
         $this->assertNotEmpty($matches, "No matches found for $regex");
         return $matches;
     }


### PR DESCRIPTION
Using grabMatchesFromEmail works with the encoded email source instead of the plain text one. This prevents some regexes from matching correctly.

PR #84 fixed this for `seeInEmail` and `dontSeeInEmail`, but forgot `grabMatchesFromEmail`.

Fixes #83
