### PR TITLE
Relax subject parameter in Email, as it can be null in mailcatcher

### DIFF
--- a/src/Util/Email.php
+++ b/src/Util/Email.php
@@ -27,7 +27,7 @@ class Email
     /**
      * @param string[] $recipients
      */
-    public function __construct(int $id, array $recipients, string $subject, string $source)
+    public function __construct(int $id, array $recipients, ?string $subject, string $source)
     {
         $this->id = $id;
         $this->recipients = $recipients;


### PR DESCRIPTION
Mailcatcher can return null in subject. Now that PHP8 is strict, passing null will cause an type error.